### PR TITLE
Fix implicit conversion from float to int loses precision exception

### DIFF
--- a/src/lib/jpgraph_regstat.php
+++ b/src/lib/jpgraph_regstat.php
@@ -82,7 +82,7 @@ class Spline {
 
         // Binary search to find interval
         while( $max-$min > 1 ) {
-            $k = ($max+$min) / 2;
+            $k = floor(($max+$min) / 2);
             if( $this->xdata[$k] > $xpoint )
             $max=$k;
             else

--- a/src/lib/jpgraph_regstat.php
+++ b/src/lib/jpgraph_regstat.php
@@ -82,7 +82,7 @@ class Spline {
 
         // Binary search to find interval
         while( $max-$min > 1 ) {
-            $k = floor(($max+$min) / 2);
+            $k = (int) floor(($max+$min) / 2);
             if( $this->xdata[$k] > $xpoint )
             $max=$k;
             else


### PR DESCRIPTION
We have encountered this problem in our PHP 8.1 environment. This solution seems to be working fine as it should be what PHP used to do by default.